### PR TITLE
Unify macOS bookmark form styling

### DIFF
--- a/Aarle.xcodeproj/project.pbxproj
+++ b/Aarle.xcodeproj/project.pbxproj
@@ -51,6 +51,10 @@
 		D10A00022E5B000100000001 /* TagTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10A00002E5B000100000001 /* TagTextField.swift */; };
 		D10A00032E5B000100000001 /* TagTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10A00002E5B000100000001 /* TagTextField.swift */; };
 		D10A00042E5B000100000001 /* TagTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10A00002E5B000100000001 /* TagTextField.swift */; };
+		D10B00012E5B000200000001 /* BookmarkFormFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10B00002E5B000200000001 /* BookmarkFormFields.swift */; };
+		D10B00022E5B000200000001 /* BookmarkFormFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10B00002E5B000200000001 /* BookmarkFormFields.swift */; };
+		D10B00032E5B000200000001 /* BookmarkFormFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10B00002E5B000200000001 /* BookmarkFormFields.swift */; };
+		D10B00042E5B000200000001 /* BookmarkFormFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10B00002E5B000200000001 /* BookmarkFormFields.swift */; };
 		C5782B382782E53800321138 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = C5782B372782E53800321138 /* KeychainAccess */; };
 		C5782B3A2782E82800321138 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = C5782B392782E82800321138 /* KeychainAccess */; };
 		C57A5E562B2C1609005F4EB7 /* MinimalProgressViewStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57A5E552B2C1609005F4EB7 /* MinimalProgressViewStyle.swift */; };
@@ -173,6 +177,7 @@
 		C56A379627A1DCA2005A5B8E /* Aarle--macOS--Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Aarle--macOS--Info.plist"; sourceTree = "<group>"; };
 		C5782B302781E97900321138 /* LinkItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkItemView.swift; sourceTree = "<group>"; };
 		D10A00002E5B000100000001 /* TagTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagTextField.swift; sourceTree = "<group>"; };
+		D10B00002E5B000200000001 /* BookmarkFormFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkFormFields.swift; sourceTree = "<group>"; };
 		C57A5E552B2C1609005F4EB7 /* MinimalProgressViewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimalProgressViewStyle.swift; sourceTree = "<group>"; };
 		C585F1F027A51EAF00AB0A6F /* ClientFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientFactory.swift; sourceTree = "<group>"; };
 		C585F1FF27A5429000AB0A6F /* Aarle--iOS--Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Aarle--iOS--Info.plist"; sourceTree = "<group>"; };
@@ -303,6 +308,7 @@
 				C57A5E552B2C1609005F4EB7 /* MinimalProgressViewStyle.swift */,
 				C5D68F6F2B30235800BE50EC /* EmptyDetailView.swift */,
 				D10A00002E5B000100000001 /* TagTextField.swift */,
+				D10B00002E5B000200000001 /* BookmarkFormFields.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -651,6 +657,7 @@
 				C5165653278EB849006A55A7 /* InitialContentView.swift in Sources */,
 				C585F1F127A51EAF00AB0A6F /* ClientFactory.swift in Sources */,
 				D10A00012E5B000100000001 /* TagTextField.swift in Sources */,
+				D10B00012E5B000200000001 /* BookmarkFormFields.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -678,6 +685,7 @@
 				C5165654278EB849006A55A7 /* InitialContentView.swift in Sources */,
 				C585F1F227A51EAF00AB0A6F /* ClientFactory.swift in Sources */,
 				D10A00022E5B000100000001 /* TagTextField.swift in Sources */,
+				D10B00022E5B000200000001 /* BookmarkFormFields.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -694,6 +702,7 @@
 				C5C9BB5727895F580005086C /* ShareViewController.swift in Sources */,
 				C585F1F327A51EAF00AB0A6F /* ClientFactory.swift in Sources */,
 				D10A00032E5B000100000001 /* TagTextField.swift in Sources */,
+				D10B00032E5B000200000001 /* BookmarkFormFields.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -710,6 +719,7 @@
 				C5FAE123279BE309007E763B /* UserDefaults+Suite.swift in Sources */,
 				C585F1F427A51EAF00AB0A6F /* ClientFactory.swift in Sources */,
 				D10A00042E5B000100000001 /* TagTextField.swift in Sources */,
+				D10B00042E5B000200000001 /* BookmarkFormFields.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Shared/Views/BookmarkFormFields.swift
+++ b/Shared/Views/BookmarkFormFields.swift
@@ -1,0 +1,133 @@
+//
+//  BookmarkFormFields.swift
+//  Aarle
+//
+//  Shared macOS form fields for Add and Edit bookmark views.
+//
+
+import SwiftUI
+import Types
+
+struct BookmarkFormFields: View {
+    @Binding var urlString: String
+    @Binding var title: String
+    @Binding var description: String
+    @Binding var tagsString: String
+    var allTags: [Tag]
+    var favoriteTags: [Tag]
+    var isDisabled: Bool
+    var onToggleFavorite: (Tag, Bool) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            fieldSection("URL") {
+                TextField("URL", text: $urlString)
+                    .disableAutocorrection(true)
+                    .disabled(isDisabled)
+            }
+
+            fieldSection("Title") {
+                TextField("Title", text: $title)
+                    .disabled(isDisabled)
+            }
+
+            fieldSection("Description") {
+                TextEditor(text: $description)
+                    .frame(minHeight: 80)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 5)
+                            .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                    )
+                    .disabled(isDisabled)
+            }
+
+            if !favoriteTags.isEmpty {
+                fieldSection("Favorites") {
+                    FlowLayout(spacing: 8) {
+                        ForEach(favoriteTags) { tag in
+                            Toggle(
+                                tag.name,
+                                isOn: Binding(
+                                    get: { isTagActive(tag) },
+                                    set: { onToggleFavorite(tag, $0) }
+                                )
+                            )
+                            .toggleStyle(.button)
+                            .buttonStyle(.bordered)
+                        }
+                    }
+                }
+            }
+
+            fieldSection("Tags") {
+                TagTextField(
+                    tagsString: $tagsString,
+                    allTags: allTags,
+                    placeholder: "Space-separated tags"
+                )
+            }
+        }
+        .textFieldStyle(.roundedBorder)
+    }
+
+    private func isTagActive(_ tag: Tag) -> Bool {
+        let tags = tagsString.components(separatedBy: " ").filter { !$0.isEmpty }
+        return tags.contains(tag.name)
+    }
+
+    @ViewBuilder
+    private func fieldSection<Content: View>(_ label: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(.headline)
+                .foregroundStyle(.secondary)
+            content()
+        }
+    }
+}
+
+private struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let rows = computeRows(proposal: proposal, subviews: subviews)
+        var height: CGFloat = 0
+        for (index, row) in rows.enumerated() {
+            let rowHeight = row.map { subviews[$0].sizeThatFits(.unspecified).height }.max() ?? 0
+            height += rowHeight
+            if index < rows.count - 1 { height += spacing }
+        }
+        return CGSize(width: proposal.width ?? 0, height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let rows = computeRows(proposal: proposal, subviews: subviews)
+        var y = bounds.minY
+        for row in rows {
+            let rowHeight = row.map { subviews[$0].sizeThatFits(.unspecified).height }.max() ?? 0
+            var x = bounds.minX
+            for index in row {
+                let size = subviews[index].sizeThatFits(.unspecified)
+                subviews[index].place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
+                x += size.width + spacing
+            }
+            y += rowHeight + spacing
+        }
+    }
+
+    private func computeRows(proposal: ProposedViewSize, subviews: Subviews) -> [[Int]] {
+        let maxWidth = proposal.width ?? .infinity
+        var rows: [[Int]] = [[]]
+        var currentWidth: CGFloat = 0
+        for (index, subview) in subviews.enumerated() {
+            let size = subview.sizeThatFits(.unspecified)
+            if currentWidth + size.width > maxWidth && !rows[rows.count - 1].isEmpty {
+                rows.append([])
+                currentWidth = 0
+            }
+            rows[rows.count - 1].append(index)
+            currentWidth += size.width + spacing
+        }
+        return rows
+    }
+}

--- a/Shared/Views/LinkAddView.swift
+++ b/Shared/Views/LinkAddView.swift
@@ -47,6 +47,106 @@ struct LinkAddView: View {
 
   var form: some View {
     @Bindable var overallAppState = overallAppState
+    #if os(macOS)
+    return macOSForm
+    #else
+    return iOSForm
+    #endif
+  }
+
+  #if os(macOS)
+  private var macOSForm: some View {
+    @Bindable var overallAppState = overallAppState
+    return VStack(alignment: .leading, spacing: 16) {
+      BookmarkFormFields(
+        urlString: $overallAppState.addState.urlString,
+        title: $overallAppState.addState.title,
+        description: $overallAppState.addState.description,
+        tagsString: $overallAppState.addState.tagsString,
+        allTags: overallAppState.tagState.tags,
+        favoriteTags: overallAppState.tagState.favoriteTags,
+        isDisabled: overallAppState.addState.isLoadingMetadata,
+        onToggleFavorite: { tag, isOn in
+          if isOn {
+            overallAppState.addState.tagsString = overallAppState.tagState.addingTag(
+              tag, toTagsString: overallAppState.addState.tagsString)
+          } else {
+            overallAppState.addState.tagsString = overallAppState.tagState.removingTag(
+              tag, fromTagsString: overallAppState.addState.tagsString)
+          }
+        }
+      )
+
+      VStack(alignment: .leading, spacing: 8) {
+        Text("Options")
+          .font(.headline)
+          .foregroundStyle(.secondary)
+        Toggle("Mark as Unread", isOn: $overallAppState.addState.markAsUnread)
+        Toggle("Download for offline reading", isOn: $overallAppState.addState.shouldArchive)
+      }
+
+      if overallAppState.addState.linkdingReachability != .unknown
+          || overallAppState.addState.metadataReachability != .unknown {
+        VStack(alignment: .leading, spacing: 8) {
+          Text("Services")
+            .font(.headline)
+            .foregroundStyle(.secondary)
+          if overallAppState.addState.linkdingReachability != .unknown {
+            HStack {
+              reachabilityIcon(overallAppState.addState.linkdingReachability)
+              Text("Linkding")
+              Spacer()
+              reachabilityLabel(overallAppState.addState.linkdingReachability)
+            }
+          }
+          if overallAppState.addState.metadataReachability != .unknown {
+            HStack {
+              reachabilityIcon(overallAppState.addState.metadataReachability)
+              Text("Metadata Service")
+              Spacer()
+              reachabilityLabel(overallAppState.addState.metadataReachability)
+            }
+          }
+        }
+      }
+
+      HStack {
+        if onCancel != nil {
+          Button("Cancel") {
+            onCancel?()
+          }
+          .buttonStyle(.bordered)
+          .keyboardShortcut(.cancelAction)
+        }
+
+        Spacer()
+
+        Button(action: {
+          save()
+        }) {
+          HStack {
+            if overallAppState.addState.isSaving {
+              ProgressView()
+                .scaleEffect(0.8)
+            }
+            Text("Add")
+          }
+        }
+        .buttonStyle(.borderedProminent)
+        .keyboardShortcut("s", modifiers: [.command])
+        .disabled(saveButtonDisabled || overallAppState.addState.isLoadingMetadata || overallAppState.addState.isSaving || overallAppState.addState.linkdingReachability == .unreachable)
+      }
+    }
+    .onChange(of: isEditingURL) { _, isEditing in
+      if isEditing == false {
+        handleURLChange(overallAppState.addState.urlString)
+      }
+    }
+  }
+  #endif
+
+  private var iOSForm: some View {
+    @Bindable var overallAppState = overallAppState
     return Form {
       Section(header: "Main Information") {
         TextField("URL", text: $overallAppState.addState.urlString)
@@ -95,7 +195,7 @@ struct LinkAddView: View {
         tagsString: $overallAppState.addState.tagsString,
         allTags: overallAppState.tagState.tags
       )
-      
+
       Section(header: "Options") {
         Toggle("Mark as Unread", isOn: $overallAppState.addState.markAsUnread)
         Toggle("Download for offline reading", isOn: $overallAppState.addState.shouldArchive)
@@ -130,9 +230,9 @@ struct LinkAddView: View {
           }
           .buttonStyle(.bordered)
         }
-        
+
         Spacer()
-        
+
         Button(action: {
           save()
         }) {

--- a/Shared/Views/LinkEditView.swift
+++ b/Shared/Views/LinkEditView.swift
@@ -54,115 +54,58 @@ struct LinkEditView: View {
         #endif
     }
 
-    private var form: some View {
-        @Bindable var editState = editState
-        return VStack(alignment: .leading, spacing: 10) {
-            Section(header: "Main Information") {
-                TextField("Link", text: $editState.urlString)
-                    .disableAutocorrection(true)
-                TextField("Title", text: $editState.title)
-            }
-            Section(header: "Description") {
-                TextEditor(text: $editState.description)
-            }
-            if !editState.favoriteTags.isEmpty {
-                Section(header: "Favorites") {
-                    ForEach(editState.favoriteTags) { tag in
-                        Toggle(
-                            tag.name,
-                            isOn: Binding(
-                                get: {
-                                    editState.tagsStringContains(tag)
-                                },
-                                set: { newValue in
-                                    if newValue {
-                                        editState.appendTag(tag)
-                                    } else {
-                                        editState.removeTag(tag)
-                                    }
-                                }
-                            )
-                        )
-                    }
-                }
-            }
-            TagTextField(
-                tagsString: $editState.tagsString,
-                allTags: editState.allTags
-            )
-        }
-    }
-
     private var macOSForm: some View {
         @Bindable var editState = editState
-        return HStack {
-            VStack {
-                Form {
-                    TextField("Link:", text: $editState.urlString)
-                        .textFieldStyle(RoundedBorderTextFieldStyle())
-                        .disableAutocorrection(true)
-                    TextField("Title:", text: $editState.title)
-                        .textFieldStyle(RoundedBorderTextFieldStyle())
-                    TextEditor(text: $editState.description)
-                        .formLabel(Text("Notes:"))
-                        .frame(maxHeight: 400)
-                    TagTextField(
-                        tagsString: $editState.tagsString,
-                        allTags: editState.allTags,
-                        placeholder: "Tags:"
-                    )
-                    if !editState.favoriteTags.isEmpty {
-                        ForEach(editState.favoriteTags) { tag in
-                            Toggle(
-                                tag.name,
-                                isOn: Binding(
-                                    get: {
-                                        editState.tagsStringContains(tag)
-                                    },
-                                    set: { newValue in
-                                        if newValue {
-                                            editState.appendTag(tag)
-                                        } else {
-                                            editState.removeTag(tag)
-                                        }
-                                    }
-                                )
-                            )
+        return ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                BookmarkFormFields(
+                    urlString: $editState.urlString,
+                    title: $editState.title,
+                    description: $editState.description,
+                    tagsString: $editState.tagsString,
+                    allTags: editState.allTags,
+                    favoriteTags: editState.favoriteTags,
+                    isDisabled: false,
+                    onToggleFavorite: { tag, isOn in
+                        if isOn {
+                            editState.appendTag(tag)
+                        } else {
+                            editState.removeTag(tag)
                         }
                     }
-                    if !editState.isEditingArchiveLink {
-                        Toggle("Unread", isOn: $editState.unread)
+                )
+
+                if !editState.isEditingArchiveLink {
+                    Toggle("Unread", isOn: $editState.unread)
+                }
+
+                HStack {
+                    if editState.isEditingArchiveLink {
+                        Button {
+                            Task { await editState.markCurrentAsRead() }
+                        } label: {
+                            Label("Mark as Read", systemImage: "checkmark.circle")
+                        }
                     }
                     Spacer()
-                    HStack {
-                        if editState.isEditingArchiveLink {
-                            Button {
-                                Task { await editState.markCurrentAsRead() }
-                            } label: {
-                                Label("Mark as Read", systemImage: "checkmark.circle")
-                            }
+                    if showCancelButton {
+                        Button("Cancel", role: .cancel) {
+                            editState.closeEditUI()
                         }
-                        Spacer()
-                        if showCancelButton {
-                            Button("Cancel", role: .cancel) {
-                                editState.closeEditUI()
-                            }
-                            .keyboardShortcut(.cancelAction)
-                        }
-                        Button("Save") {
-                            Task { await editState.save() }
-                            if showCancelButton {
-                                editState.closeEditUI()
-                            }
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .keyboardShortcut("s", modifiers: [.command])
+                        .keyboardShortcut(.cancelAction)
                     }
+                    Button("Save") {
+                        Task { await editState.save() }
+                        if showCancelButton {
+                            editState.closeEditUI()
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .keyboardShortcut("s", modifiers: [.command])
                 }
             }
-            Spacer()
+            .padding()
         }
-        .padding()
     }
 #if os(iOS)
     private var iOSForm: some View {
@@ -221,29 +164,3 @@ struct LinkEditView: View {
 #endif
 }
 
-/// https://gist.github.com/marcprux/afd2f80baa5b6d60865182a828e83586
-/// Alignment guide for aligning a text field in a `Form`.
-/// Thanks for Jim Dovey  https://developer.apple.com/forums/thread/126268
-extension HorizontalAlignment {
-    private enum ControlAlignment: AlignmentID {
-        static func defaultValue(in context: ViewDimensions) -> CGFloat {
-            return context[HorizontalAlignment.center]
-        }
-    }
-
-    static let controlAlignment = HorizontalAlignment(ControlAlignment.self)
-}
-
-public extension View {
-    /// Attaches a label to this view for laying out in a `Form`
-    /// - Parameter view: the label view to use
-    /// - Returns: an `HStack` with an alignment guide for placing in a form
-    func formLabel<V: View>(_ view: V) -> some View {
-        HStack {
-            view
-            self
-                .alignmentGuide(.controlAlignment) { $0[.leading] }
-        }
-        .alignmentGuide(.leading) { $0[.controlAlignment] }
-    }
-}


### PR DESCRIPTION
## Summary
- Extract shared `BookmarkFormFields` view used by both Add and Edit bookmark views on macOS
- Consistent styling: rounded border text fields, labeled sections, flow-layout favorite tag toggles
- Add Cmd+S shortcut and Escape cancel shortcut to Add view
- Remove unused `formLabel` extension and `HorizontalAlignment.controlAlignment`

## Test plan
- [ ] Build and run macOS app — verify Add and Edit bookmark forms look identical
- [ ] Build and run iOS app — verify no regressions (separate code paths)
- [ ] Test share extension on macOS — verify consistent styling
- [ ] Test favorite tag toggles render as horizontal button row

🤖 Generated with [Claude Code](https://claude.com/claude-code)