### PR TITLE
Fix offline unread list sort order after retries

### DIFF
--- a/Archive/Sources/Archive/ArchiveState.swift
+++ b/Archive/Sources/Archive/ArchiveState.swift
@@ -171,7 +171,7 @@ public final class ArchiveState: ArchiveStateProtocol {
                 description: archiveLink.description,
                 tags: archiveLink.tags,
                 private: false,
-                created: Date()
+                created: archiveLink.dateAdded
             )
 
             try? deleteLink(link: archiveLink)
@@ -197,7 +197,7 @@ public final class ArchiveState: ArchiveStateProtocol {
             description: archiveLink.description,
             tags: archiveLink.tags,
             private: false,
-            created: Date()
+            created: archiveLink.dateAdded
         )
 
         // Remove the failed entry


### PR DESCRIPTION
## Summary
- `retryAllFailed()` and `retryFailedDownload()` were using `created: Date()` when reconstructing `Link` objects for re-download, discarding the original bookmark creation date
- This caused retried entries to appear at the top of the offline list with the current timestamp instead of their original position
- Fixed by preserving `archiveLink.dateAdded` as the `created` date

## Test plan
- [ ] Trigger a failed archive download, then retry it — verify the entry stays in its original position in the list
- [ ] Retry all failed downloads — verify the list order matches the online unread order

🤖 Generated with [Claude Code](https://claude.com/claude-code)